### PR TITLE
fix: return empty array in case there are no resultsets #UTCORE-121

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = function(namespaces, imports = [], validations = [], destinatio
                     receive(msg, $meta) {
                         if (msg && msg.$outcome) {
                             this.outcome(msg.$outcome, $meta);
+                            if (Object.keys(msg).length === 1) return [];
                             delete msg.$outcome;
                         }
                         return msg;


### PR DESCRIPTION
return empty array in case there are no resultsets